### PR TITLE
[SERVER] refactor: S3 대체제 localstack 설정

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Always LF for shell scripts (prevents CRLF issues in Linux containers)
+*.sh text eol=lf
+gradlew text eol=lf
+gradlew.bat text eol=crlf

--- a/SERVER/src/main/java/com/ssafy/projectree/domain/file/usecase/S3Service.java
+++ b/SERVER/src/main/java/com/ssafy/projectree/domain/file/usecase/S3Service.java
@@ -38,8 +38,9 @@ public class S3Service {
         metadata.setContentLength(file.getSize());
         metadata.setContentType(file.getContentType());
 
-        InputStream inputStream = file.getInputStream();
-        amazonS3Client.putObject(new PutObjectRequest(bucket, path, inputStream, metadata));
+        try (InputStream inputStream = file.getInputStream()) {
+            amazonS3Client.putObject(new PutObjectRequest(bucket, path, inputStream, metadata));
+        }
 
         return amazonS3Client.getUrl(bucket, path).toString();
     }

--- a/SERVER/src/main/java/com/ssafy/projectree/domain/workspace/usecase/TeamService.java
+++ b/SERVER/src/main/java/com/ssafy/projectree/domain/workspace/usecase/TeamService.java
@@ -125,7 +125,7 @@ public class TeamService {
         }
 
         Member newMember = memberService.findByEmail(dto.getEmail());
-        if (newMember.isDeleted() || newMember == null) {
+        if (newMember == null || newMember.isDeleted()) {
             throw new BusinessLogicException(ErrorCode.USER_NOT_FOUND_ERROR, "존재하지 않는 사용자입니다.");
         }
 

--- a/SERVER/src/main/java/com/ssafy/projectree/global/config/S3Config.java
+++ b/SERVER/src/main/java/com/ssafy/projectree/global/config/S3Config.java
@@ -3,6 +3,7 @@ package com.ssafy.projectree.global.config;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
@@ -21,13 +22,24 @@ public class S3Config {
     @Value("${spring.cloud.aws.s3.region}")
     private String region;
 
+    @Value("${spring.cloud.aws.endpoint:}")
+    private String endpoint;
+
     @Bean
     public AmazonS3 s3Builder() {
         AWSCredentials basicAwsCredentials = new BasicAWSCredentials(accessKey, secretKey);
 
-        return AmazonS3ClientBuilder.standard()
-                .withCredentials(new AWSStaticCredentialsProvider(basicAwsCredentials))
-                .withRegion(region)
-                .build();
+        AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(basicAwsCredentials));
+
+        if (endpoint != null && !endpoint.isBlank()) {
+            builder.withEndpointConfiguration(
+                    new AwsClientBuilder.EndpointConfiguration(endpoint, region));
+            builder.withPathStyleAccessEnabled(true);
+        } else {
+            builder.withRegion(region);
+        }
+
+        return builder.build();
     }
 }

--- a/SERVER/src/main/java/com/ssafy/projectree/global/exception/GlobalExceptionHandler.java
+++ b/SERVER/src/main/java/com/ssafy/projectree/global/exception/GlobalExceptionHandler.java
@@ -31,16 +31,17 @@ public class GlobalExceptionHandler {
 
         return new ResponseEntity<>(res, HttpStatus.OK);
     }
-//
-//    @ExceptionHandler(Exception.class)
-//    public ResponseEntity<CommonResponse<?>> handleException(Exception e) {
-//
-//        CommonResponse<?> res = CommonResponse.fail(
-//                ErrorCode.SERVER_ERROR, ErrorCode.SERVER_ERROR.getDefaultMessage()
-//        );
-//
-//        return new ResponseEntity<>(res, HttpStatus.OK);
-//    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CommonResponse<?>> handleException(Exception e) {
+        log.error("Unhandled exception: {}", e.getMessage(), e);
+
+        CommonResponse<?> res = CommonResponse.fail(
+                ErrorCode.SERVER_ERROR, ErrorCode.SERVER_ERROR.getDefaultMessage()
+        );
+
+        return new ResponseEntity<>(res, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
 
     @ExceptionHandler(AIServiceException.class)
     public CommonResponse<Void> handleAiException(AIServiceException e){


### PR DESCRIPTION
## Issue Flag

없음 (버그 수정 및 개발 환경 설정)

## Motivation

프로덕션 배포 중단 기간 동안 AWS S3 대신 LocalStack을 사용하는 환경에서
`POST /api/workspaces` (파일 포함) 요청 시 500 Internal Server Error 발생.

원인 분석 결과, 환경변수 체인은 완벽하게 연결되어 있었으나
`S3Config`가 `spring.cloud.aws.endpoint` 값을 읽지 않아
S3 클라이언트가 실제 AWS(`test`/`test` 자격증명)로 연결을 시도하고 있었음.

추가로 LocalStack init 스크립트(`init-aws.sh`)가 Windows CRLF 줄바꿈으로
인해 Linux 컨테이너에서 실행 실패 → 버킷 미생성 상태였음.

## Problem Solving

**[핵심 수정] `S3Config.java`**
- `@Value("${spring.cloud.aws.endpoint:}")` 주입 추가
- `endpoint`가 존재하면 LocalStack용 `withEndpointConfiguration()` + `withPathStyleAccessEnabled(true)` 적용
- `endpoint`가 없으면 기존 실 AWS용 `withRegion()` 유지
- LocalStack이 virtual-hosted URL(`bucket.localstack:4566`) 대신 path-style URL(`localstack:4566/bucket`)만 지원하기 때문에 `withPathStyleAccessEnabled(true)` 필수

**[환경 수정] `scripts/init-aws.sh`**
- CRLF → LF 줄바꿈 변환 (Windows에서 작성된 스크립트가 Linux 컨테이너에서 실행 불가 문제 해결)
- LocalStack 재시작 시 `projectree-local` 버킷 자동 생성 보장

**[방어 코드] `GlobalExceptionHandler.java`**
- 주석 처리되어 있던 `Exception` 핸들러 복원
- 미처리 예외 발생 시 스택 트레이스 로깅 + 표준 에러 응답 반환 (500 디버깅 용이)

**[버그 수정] `TeamService.java`**
- `newMember.isDeleted() || newMember == null` → `newMember == null || newMember.isDeleted()` 순서 수정 (NPE 방지)

**[리소스 관리] `S3Service.java`**
- `InputStream`을 try-with-resources로 변경하여 S3 업로드 후 스트림 자동 close

## To Reviewer

- 로컬 개발 환경에서 `docker compose up` 후 바로 파일 업로드가 되지 않는다면,
  LocalStack 컨테이너 로그에서 `init-aws.sh` 실행 결과 확인 필요
- 실제 AWS로 전환 시에는 `.env`에서 `SPRING_CLOUD_AWS_ENDPOINT` 값만 제거하면
  자동으로 실 AWS 모드로 동작
